### PR TITLE
refactor(benchmark): implement lazy loading for image libraries and benchmark modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cov.xml
 .vscode/
 Prj
 Data
+.data/
 conductor
 AGENTS.md
 GEMINI.md

--- a/plans/lazy-imports-implementation-plan.md
+++ b/plans/lazy-imports-implementation-plan.md
@@ -1,0 +1,546 @@
+# Lazy Imports Implementation Plan
+
+## Problem Summary
+
+**Current Issue:** Running `imgread_data imagenette` (which only needs `datasets.py`) triggers the package `__init__.py`, which imports benchmarking modules, causing jpeg4py to be imported and tested, even though it's not needed for data downloading.
+
+**Error:**
+```
+Exception ignored in: <function JPEG.__del__ at 0x7f1fa189ee80>
+Traceback (most recent call last):
+  File "/home/aya/Prj/imgread_benchmark/.venv/lib/python3.12/site-packages/jpeg4py/_py.py", line 215, in __del__
+    if self.decompressor is not None:
+       ^^^^^^^^^^^^^^^^^
+AttributeError: 'JPEG' object has no attribute 'decompressor'
+```
+
+**Root Cause Chain:**
+```
+imgread_data
+  → imports imgread_benchmark.cl_data
+  → Python loads imgread_benchmark package
+  → __init__.py imports: BenchmarkImgRead, get_img_filenames, img_lib_available
+  → img_lib_available triggers _build_img_lib_available()
+  → tests jpeg4py by importing and creating JPEG object
+  → jpeg4py has __del__ bug → AttributeError
+```
+
+## Solution Strategy
+
+Implement lazy imports at two levels:
+1. **Package level** (`__init__.py`): Use lazy imports for heavy modules
+2. **Module level** (`read_img.py`, `img_libs_pkgs.py`): Defer library detection until actually needed
+
+**Goal:** `imgread_data` command should run without triggering any image library imports.
+
+---
+
+## Phase 1: Fix Package `__init__.py`
+
+**File:** `src/imgread_benchmark/__init__.py`
+
+**Approach:** Replace direct imports with lazy import mechanism using `__getattr__`.
+
+**Current Code:**
+```python
+from .benchmark import BenchmarkImgRead
+from .get_img_filenames import get_img_filenames
+from .img_libs.img_libs_pkgs import img_lib_available
+
+
+__all__ = ["get_img_filenames", "BenchmarkImgRead", "img_lib_available"]
+```
+
+**New Code:**
+```python
+def __getattr__(name: str):
+    """Lazy import heavy modules only when accessed."""
+    if name == "BenchmarkImgRead":
+        from .benchmark import BenchmarkImgRead
+        return BenchmarkImgRead
+    elif name == "get_img_filenames":
+        from .get_img_filenames import get_img_filenames
+        return get_img_filenames
+    elif name == "img_lib_available":
+        from .img_libs.img_libs_pkgs import img_lib_available
+        return img_lib_available
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["get_img_filenames", "BenchmarkImgRead", "img_lib_available"]
+```
+
+**Benefits:**
+- Only loads modules when accessed
+- `imgread_data` won't trigger benchmarking imports
+- Maintains API compatibility
+- Python 3.7+ standard pattern
+
+---
+
+## Phase 2: Lazy Image Library Detection
+
+**File:** `src/imgread_benchmark/img_libs/img_libs_pkgs.py`
+
+**Current Problem:** `img_lib_available` is computed at module import time (line 60), triggering jpeg4py test.
+
+**Solution:** Convert to cached lazy function.
+
+**Current Code (Lines 49-60):**
+```python
+def _build_img_lib_available() -> list[str]:
+    available: list[str] = []
+    for lib_name in lib_to_package:
+        if find_spec(lib_name) is None:
+            continue
+        if lib_name == "jpeg4py" and not _is_jpeg4py_usable():
+            continue
+        available.append(lib_name)
+    return available
+
+
+img_lib_available = _build_img_lib_available()
+```
+
+**New Code:**
+```python
+from functools import lru_cache
+
+@lru_cache(maxsize=1)
+def get_img_lib_available() -> list[str]:
+    """Get list of available image libraries (lazy, cached)."""
+    available: list[str] = []
+    for lib_name in lib_to_package:
+        if find_spec(lib_name) is None:
+            continue
+        if lib_name == "jpeg4py" and not _is_jpeg4py_usable():
+            continue
+        available.append(lib_name)
+    return available
+
+
+# For backwards compatibility - deprecated, use get_img_lib_available()
+img_lib_available = get_img_lib_available()
+```
+
+---
+
+## Phase 3: Update `read_img.py`
+
+**File:** `src/imgread_benchmark/read_img.py`
+
+**Current Problem:** Module-level code (lines 43-47) loads all image libraries at import time.
+
+**Current Code (Lines 14, 43-47):**
+```python
+from .img_libs.img_libs_pkgs import img_lib_available, lib_to_package
+
+# ... lines 14-42 ...
+
+img_libs = {}
+
+
+for img_lib in img_lib_available:
+    img_libs[img_lib] = load_lib(img_lib)
+```
+
+**New Code:**
+```python
+from .img_libs.img_libs_pkgs import lib_to_package, get_img_lib_available
+
+# ... lines 14-42 ...
+
+@lru_cache(maxsize=1)
+def get_img_libs() -> dict:
+    """Get loaded image libraries (lazy, cached)."""
+    return {lib: load_lib(lib) for lib in get_img_lib_available()}
+
+
+# For backwards compatibility
+img_libs = get_img_libs()
+```
+
+**Also update the function dictionaries (lines 50-70):**
+
+**Current:**
+```python
+def get_func_dict(
+    func_name: str, func_dict: dict[str, Any]
+) -> dict[str, Callable[[str], Any]]:
+    """Return dict lib_name: func for given func_name"""
+    return {
+        lib_name: graceful_degradation(func)
+        for lib_name in img_lib_available
+        if (func := getattr(func_dict[lib_name], func_name, None)) is not None
+    }
+
+
+read_img: Dict[str, Callable[[str], Any]] = get_func_dict("read_img", img_libs)
+read_img_pil: Dict[str, Callable[[str], Image.Image]] = get_func_dict(
+    "read_img_pil", img_libs
+)
+read_img_ndarray: Dict[str, Callable[[str], ndarray]] = get_func_dict(
+    "read_img_ndarray", img_libs
+)
+read_img_version: Dict[str, str] = {
+    lib_name: pkg_version(lib_to_package[lib_name]) for lib_name in img_lib_available
+}
+```
+
+**New:**
+```python
+def get_func_dict(
+    func_name: str, func_dict: dict[str, Any]
+) -> dict[str, Callable[[str], Any]]:
+    """Return dict lib_name: func for given func_name"""
+    return {
+        lib_name: graceful_degradation(func)
+        for lib_name in get_img_lib_available()
+        if (func := getattr(func_dict[lib_name], func_name, None)) is not None
+    }
+
+
+@lru_cache(maxsize=1)
+def get_read_img() -> Dict[str, Callable[[str], Any]]:
+    """Get read_img function dict (lazy, cached)."""
+    return get_func_dict("read_img", get_img_libs())
+
+
+@lru_cache(maxsize=1)
+def get_read_img_pil() -> Dict[str, Callable[[str], Image.Image]]:
+    """Get read_img_pil function dict (lazy, cached)."""
+    return get_func_dict("read_img_pil", get_img_libs())
+
+
+@lru_cache(maxsize=1)
+def get_read_img_ndarray() -> Dict[str, Callable[[str], ndarray]]:
+    """Get read_img_ndarray function dict (lazy, cached)."""
+    return get_func_dict("read_img_ndarray", get_img_libs())
+
+
+@lru_cache(maxsize=1)
+def get_read_img_version() -> Dict[str, str]:
+    """Get version dict for image libraries (lazy, cached)."""
+    return {
+        lib_name: pkg_version(lib_to_package[lib_name])
+        for lib_name in get_img_lib_available()
+    }
+
+
+# For backwards compatibility
+read_img = get_read_img()
+read_img_pil = get_read_img_pil()
+read_img_ndarray = get_read_img_ndarray()
+read_img_version = get_read_img_version()
+```
+
+---
+
+## Phase 4: Update Dependent Files
+
+### File: `src/imgread_benchmark/cl_versions.py`
+
+**Current (Line 5):**
+```python
+from .read_img import img_libs, read_img_version
+```
+
+**New:**
+```python
+from .read_img import get_img_libs, get_read_img_version
+
+# Use the lazy functions
+img_libs = get_img_libs()
+read_img_version = get_read_img_version()
+```
+
+**Update function usage (lines 24-31):**
+```python
+def imgread_versions(
+    cfg: AppConfig,
+) -> None:
+    """Imgread_benchmark. Helpers utils for check and benchmark libs for read image files."""
+    print("Imgread. Helpers utils for check and benchmark libs for read image files.")
+    img_libs = get_img_libs()  # Changed from module-level
+    versions = get_read_img_version()  # Changed from module-level
+    print(f"Available {len(img_libs)} image libs:")
+
+    if cfg.version:
+        print(f"version: {__version__}")
+    else:
+        max_len = max(len(lib_name) for lib_name in img_libs)
+        for img_lib in img_libs:
+            print(f"    {img_lib:{max_len}} {versions[img_lib]}")  # Use versions dict
+```
+
+---
+
+## Phase 5: Improve jpeg4py Error Handling
+
+**File:** `src/imgread_benchmark/img_libs/img_libs_pkgs.py`
+
+**Current `_is_jpeg4py_usable()` (Lines 19-46):**
+Has overly broad `except Exception:` that catches everything.
+
+**Improved Version:**
+```python
+def _is_jpeg4py_usable() -> bool:
+    """Test if jpeg4py is working (has known __del__ bug)."""
+    try:
+        import jpeg4py
+        from pathlib import Path
+        import tempfile
+
+        minimal_jpeg = (
+            b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+            b"\xff\xdb\x00\x43\x00\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
+            b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
+            b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
+            b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
+            b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\xff\xc0"
+            b'\x00\x11\x08\x00\x01\x00\x01\x03\x01"\x00\x02\x11\x01\x03\x11\x01\xff'
+            b"\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\xff\xda\x00"
+            b"\x0c\x03\x01\x00\x02\x11\x03\x11\x00?\x00\xfd\x9f\xff\xd9"
+        )
+
+        tmp_path = None
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+            tmp_file.write(minimal_jpeg)
+            tmp_path = tmp_file.name
+
+        try:
+            result = jpeg4py.JPEG(tmp_path).decode()
+            # Explicitly delete to trigger __del__ and catch the bug immediately
+            del result
+            return True
+        except (AttributeError, OSError, ValueError) as e:
+            # Known jpeg4py __del__ bug or other errors
+            error_str = str(e)
+            if "decompressor" in error_str:
+                # Known bug in jpeg4py's __del__ method
+                return False
+            # Other errors, log and skip
+            import warnings
+            warnings.warn(f"jpeg4py test failed: {e}", RuntimeWarning)
+            return False
+        finally:
+            if tmp_path is not None:
+                Path(tmp_path).unlink(missing_ok=True)
+    except Exception as e:
+        # Import failed or other critical error
+        import warnings
+        warnings.warn(f"jpeg4py not available: {e}", RuntimeWarning)
+        return False
+```
+
+---
+
+## Phase 6: Test Coverage
+
+### New Test File: `tests/test_lazy_imports.py`
+
+```python
+"""Test that data loading doesn't import image libraries."""
+
+import sys
+
+
+def test_data_download_no_img_libs_import(monkeypatch):
+    """Test that imgread_data doesn't import image libraries."""
+    # Track if jpeg4py was imported
+    jpeg4py_imported = [False]
+
+    original_import = __builtins__.__import__
+    def mock_import(name, *args, **kwargs):
+        if name == 'jpeg4py' or name.startswith('jpeg4py.'):
+            jpeg4py_imported[0] = True
+            raise ImportError("jpeg4py blocked for test")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(__builtins__, '__import__', mock_import)
+
+    # Import and use data download module
+    from imgread_benchmark.cl_data import download_app, DATASET_PROVIDERS
+
+    # Should not have imported jpeg4py
+    assert not jpeg4py_imported[0], "jpeg4py should not be imported for data download"
+
+    # Verify datasets are accessible
+    assert "imagenette" in DATASET_PROVIDERS
+
+
+def test_lazy_img_lib_detection():
+    """Test that image library detection is lazy."""
+    # This should not import jpeg4py
+    from imgread_benchmark.img_libs.img_libs_pkgs import get_img_lib_available
+
+    # First call should work
+    libs = get_img_lib_available()
+    assert isinstance(libs, list)
+
+    # Second call should be cached
+    libs2 = get_img_lib_available()
+    assert libs is libs2  # Same object (cached)
+
+
+def test_package_lazy_imports():
+    """Test that package imports are lazy."""
+    import imgread_benchmark
+
+    # These should not trigger benchmarking imports yet
+    assert hasattr(imgread_benchmark, '__getattr__')
+
+    # Accessing BenchmarkImgRead should trigger import
+    from imgread_benchmark import BenchmarkImgRead
+    assert BenchmarkImgRead is not None
+```
+
+### Update Existing Tests
+
+**File: `tests/test_img_libs_pkgs.py`**
+
+Add tests for new function-based API:
+```python
+def test_get_img_lib_available():
+    """Test get_img_lib_available function."""
+    from imgread_benchmark.img_libs.img_libs_pkgs import get_img_lib_available
+
+    libs = get_img_lib_available()
+    assert isinstance(libs, list)
+    # PIL should always be available (it's a required dependency)
+    assert "PIL" in libs
+
+
+def test_get_img_lib_available_cached():
+    """Test that get_img_lib_available is cached."""
+    from imgread_benchmark.img_libs.img_libs_pkgs import get_img_lib_available
+
+    libs1 = get_img_lib_available()
+    libs2 = get_img_lib_available()
+    assert libs1 is libs2
+```
+
+**File: `tests/test_datasets.py`**
+
+Verify datasets work independently:
+```python
+def test_datasets_without_img_libs(monkeypatch):
+    """Test that dataset providers work without image libraries."""
+    # Block all image library imports
+    def mock_import(name, *args, **kwargs):
+        if name in ['jpeg4py', 'cv2', 'skimage', 'imageio']:
+            raise ImportError(f"{name} blocked for test")
+        return __import__(name, *args, **kwargs)
+
+    monkeypatch.setattr(__builtins__, '__import__', mock_import)
+
+    from imgread_benchmark.datasets import DatasetProvider, ImagenetteProvider
+
+    provider = ImagenetteProvider()
+    assert provider.name == "imagenette"
+    assert provider.default_size == "full"
+
+    url = provider.get_url("160")
+    assert "imagenette2-160" in url
+```
+
+---
+
+## Implementation Order
+
+Execute phases in this order, testing after each phase:
+
+1. **Phase 5** - Improve jpeg4py error handling (independent, safer)
+2. **Phase 1** - Fix `__init__.py` lazy imports (highest impact)
+3. **Phase 2** - Lazy library detection
+4. **Phase 3** - Update `read_img.py`
+5. **Phase 4** - Update `cl_versions.py`
+6. **Phase 6** - Add test coverage
+
+### Test After Each Phase
+
+```bash
+# Test that data download works
+uv run imgread_data imagenette --size 160
+
+# Test that benchmarking still works
+uv run imgread_libs
+
+# Test all tests pass
+uv run pytest tests/ -v
+
+# Run linting
+uv run ruff check .
+```
+
+---
+
+## Backwards Compatibility
+
+✅ **Fully Maintained:**
+- Package API unchanged (`from imgread_benchmark import X` still works)
+- All existing imports continue to work
+- CLI commands unchanged
+- Module-level variables still exist (backwards compatibility layer)
+
+✅ **New API:**
+- `get_img_lib_available()` - Function-based lazy version
+- `get_img_libs()` - Function-based lazy version
+- `get_read_img()`, `get_read_img_pil()`, etc. - Function-based lazy versions
+
+⚠️ **Breaking changes:** None
+
+---
+
+## Success Criteria
+
+After implementation:
+
+1. ✅ `uv run imgread_data imagenette` runs without importing jpeg4py
+2. ✅ No AttributeError from jpeg4py `__del__`
+3. ✅ `uv run imgread_libs` still lists all available libraries
+4. ✅ All existing tests pass
+5. ✅ New tests verify lazy loading behavior
+6. ✅ Code passes linting (`ruff check .`)
+7. ✅ Backwards compatibility maintained
+
+---
+
+## Rollback Plan
+
+If issues arise:
+
+1. **Quick rollback:** Revert `__init__.py` changes (Phase 1) - immediately fixes the main issue
+2. **Partial rollback:** Keep Phase 5 (better error handling) but revert other phases
+3. **Full rollback:** Git revert to commit before changes
+
+All changes are backwards compatible, so rolling back won't break existing code.
+
+---
+
+## Future Improvements
+
+After successful implementation:
+
+1. **Consider deprecating module-level variables** in favor of functions
+2. **Add logging** to track when lazy imports are triggered
+3. **Performance testing** to ensure caching is effective
+4. **Documentation updates** to explain lazy import behavior
+5. **Consider separating `imgread_data` into its own package** for even cleaner separation
+
+---
+
+## Notes
+
+- **Python 3.7+ required** for `__getattr__` lazy import pattern (project requires 3.10+, so OK)
+- **`functools.lru_cache`** used for caching lazy function results
+- **Backwards compatibility layer** maintains existing module-level variables
+- **All changes are additive** - no deletions, only additions and refactoring
+- **Test coverage** ensures lazy loading works correctly
+
+---
+
+**Created:** 2025-02-02
+**Status:** Ready for implementation
+**Estimated time:** 2-3 hours for all phases

--- a/src/imgread_benchmark/__init__.py
+++ b/src/imgread_benchmark/__init__.py
@@ -1,6 +1,18 @@
-from .benchmark import BenchmarkImgRead
-from .get_img_filenames import get_img_filenames
-from .img_libs.img_libs_pkgs import img_lib_available
+def __getattr__(name: str):
+    """Lazy import heavy modules only when accessed."""
+    if name == "BenchmarkImgRead":
+        from .benchmark import BenchmarkImgRead
+
+        return BenchmarkImgRead
+    elif name == "get_img_filenames":
+        from .get_img_filenames import get_img_filenames
+
+        return get_img_filenames
+    elif name == "img_lib_available":
+        from .img_libs.img_libs_pkgs import img_lib_available
+
+        return img_lib_available
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = ["get_img_filenames", "BenchmarkImgRead", "img_lib_available"]

--- a/src/imgread_benchmark/benchmark.py
+++ b/src/imgread_benchmark/benchmark.py
@@ -4,13 +4,16 @@ from typing import Callable, Dict, List, Literal, Optional
 from benchmark_utils import BenchmarkIter
 
 from .get_img_filenames import get_img_filenames
-from .read_img import read_img, read_img_ndarray, read_img_pil
 
-READ_TO_FORMAT = {
-    "def": read_img,
-    "pil": read_img_pil,
-    "np": read_img_ndarray,
-}
+
+def _get_read_to_format() -> Dict[str, Callable]:
+    from .read_img import get_read_img, get_read_img_ndarray, get_read_img_pil
+
+    return {
+        "def": get_read_img(),
+        "pil": get_read_img_pil(),
+        "np": get_read_img_ndarray(),
+    }
 
 __all__ = ["BenchmarkImgRead"]
 
@@ -29,7 +32,7 @@ class BenchmarkImgRead(BenchmarkIter):
         clear_progress: bool = False,
     ):
         self._target_format = target_format
-        func_to_test = func_dict or READ_TO_FORMAT[target_format]
+        func_to_test = func_dict or _get_read_to_format()[target_format]
         img_path = img_path or "."
         if filenames is None:
             filenames = get_img_filenames(img_path, num_samples=num_samples)
@@ -46,12 +49,13 @@ class BenchmarkImgRead(BenchmarkIter):
 
     @target_format.setter
     def target_format(self, target_format: Literal["def", "pil", "np"]) -> None:
-        if target_format not in READ_TO_FORMAT:
+        read_to_format = _get_read_to_format()
+        if target_format not in read_to_format:
             print(f"{target_format} not in available format.")
-            print("available: ", ", ".join(READ_TO_FORMAT.keys()))
+            print("available: ", ", ".join(read_to_format.keys()))
         else:
             self._target_format = target_format
-            self.func_dict = READ_TO_FORMAT[target_format]
+            self.func_dict = read_to_format[target_format]
 
     @property
     def func_names(self) -> str:

--- a/src/imgread_benchmark/cl_versions.py
+++ b/src/imgread_benchmark/cl_versions.py
@@ -2,7 +2,7 @@ from argparsecfg import field_argument
 from argparsecfg.app import app
 from dataclasses import dataclass
 
-from .read_img import img_libs, read_img_version
+from .read_img import get_img_libs, get_read_img_version
 from .version import __version__
 
 
@@ -21,6 +21,8 @@ def imgread_versions(
 ) -> None:
     """Imgread_benchmark. Helpers utils for check and benchmark libs for read image files."""
     print("Imgread. Helpers utils for check and benchmark libs for read image files.")
+    img_libs = get_img_libs()
+    versions = get_read_img_version()
     print(f"Available {len(img_libs)} image libs:")
 
     if cfg.version:
@@ -28,7 +30,7 @@ def imgread_versions(
     else:
         max_len = max(len(lib_name) for lib_name in img_libs)
         for img_lib in img_libs:
-            print(f"    {img_lib:{max_len}} {read_img_version[img_lib]}")
+            print(f"    {img_lib:{max_len}} {versions[img_lib]}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/imgread_benchmark/datasets.py
+++ b/src/imgread_benchmark/datasets.py
@@ -2,6 +2,7 @@ import abc
 import tarfile
 from pathlib import Path
 import requests
+from rich.console import Console
 from rich.progress import (
     Progress,
     SpinnerColumn,
@@ -10,6 +11,8 @@ from rich.progress import (
     DownloadColumn,
     TransferSpeedColumn,
 )
+
+console = Console()
 
 
 class DatasetProvider(abc.ABC):
@@ -41,12 +44,23 @@ class DatasetProvider(abc.ABC):
     def download(self, size: str | None = None):
         """Download and extract the dataset."""
         size = size or self.default_size
+        url = self.get_url(size)
+        archive_name = Path(url).name
+        expected_dir = self.dataset_dir / Path(archive_name).stem
+
         sentinel = self.dataset_dir / ".ready"
-        if sentinel.exists():
+        if sentinel.exists() and expected_dir.exists():
+            contents = [
+                p.name for p in self.dataset_dir.iterdir() if p.name != ".ready"
+            ]
+            console.print(
+                f"[green]✓[/green] {self.name} dataset already downloaded ({size})."
+            )
+            if contents:
+                console.print(f"  Available: {', '.join(contents)}")
             return
 
-        url = self.get_url(size)
-        archive_path = self.dataset_dir / Path(url).name
+        archive_path = self.dataset_dir / archive_name
 
         response = requests.get(url, stream=True)
         response.raise_for_status()
@@ -70,6 +84,9 @@ class DatasetProvider(abc.ABC):
         self.extract(archive_path)
         archive_path.unlink(missing_ok=True)  # Remove archive after extraction
         sentinel.touch()
+        console.print(
+            f"[green]✓[/green] {self.name} dataset downloaded successfully ({size})."
+        )
 
     def extract(self, archive_path: Path):
         """Extract the dataset archive."""

--- a/src/imgread_benchmark/img_libs/img_libs_pkgs.py
+++ b/src/imgread_benchmark/img_libs/img_libs_pkgs.py
@@ -1,6 +1,7 @@
 from importlib.util import find_spec
 from pathlib import Path
 import tempfile
+from functools import lru_cache
 
 lib_to_package = {
     "PIL": "pillow",
@@ -36,14 +37,40 @@ def _is_jpeg4py_usable() -> bool:
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             tmp_file.write(minimal_jpeg)
             tmp_path = tmp_file.name
+
         try:
-            jpeg4py.JPEG(tmp_path).decode()
+            result = jpeg4py.JPEG(tmp_path).decode()
+            del result
+            return True
+        except (AttributeError, OSError, ValueError) as e:
+            error_str = str(e)
+            if "decompressor" in error_str:
+                return False
+            import warnings
+
+            warnings.warn(f"jpeg4py test failed: {e}", RuntimeWarning)
+            return False
         finally:
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
-    except Exception:
+    except Exception as e:
+        import warnings
+
+        warnings.warn(f"jpeg4py not available: {e}", RuntimeWarning)
         return False
-    return True
+
+
+@lru_cache(maxsize=1)
+def get_img_lib_available() -> list[str]:
+    """Get list of available image libraries (lazy, cached)."""
+    available: list[str] = []
+    for lib_name in lib_to_package:
+        if find_spec(lib_name) is None:
+            continue
+        if lib_name == "jpeg4py" and not _is_jpeg4py_usable():
+            continue
+        available.append(lib_name)
+    return available
 
 
 def _build_img_lib_available() -> list[str]:
@@ -57,4 +84,5 @@ def _build_img_lib_available() -> list[str]:
     return available
 
 
-img_lib_available = _build_img_lib_available()
+# For backwards compatibility - deprecated, use get_img_lib_available()
+img_lib_available = get_img_lib_available()

--- a/src/imgread_benchmark/img_libs/img_libs_pkgs.py
+++ b/src/imgread_benchmark/img_libs/img_libs_pkgs.py
@@ -1,7 +1,8 @@
+from functools import lru_cache
 from importlib.util import find_spec
 from pathlib import Path
 import tempfile
-from functools import lru_cache
+from ctypes.util import find_library
 
 lib_to_package = {
     "PIL": "pillow",
@@ -17,9 +18,40 @@ lib_to_package = {
 }
 
 
+def _has_jpeg_turbo() -> bool:
+    return (
+        find_library("turbojpeg") is not None
+        or find_library("jpeg") is not None
+        or find_library("libjpeg") is not None
+    )
+
+
+def _patch_jpeg4py_del(jpeg4py_module: object) -> None:
+    jpeg_cls = getattr(jpeg4py_module, "JPEG", None)
+    if jpeg_cls is None:
+        return
+    orig_del = getattr(jpeg_cls, "__del__", None)
+    if orig_del is None or getattr(orig_del, "__imgread_safe__", False):
+        return
+
+    def safe_del(self) -> None:
+        try:
+            orig_del(self)
+        except AttributeError:
+            return None
+
+    safe_del.__imgread_safe__ = True
+    setattr(jpeg_cls, "__del__", safe_del)
+
+
 def _is_jpeg4py_usable() -> bool:
     try:
         import jpeg4py
+
+        _patch_jpeg4py_del(jpeg4py)
+
+        if not _has_jpeg_turbo():
+            return False
 
         minimal_jpeg = (
             b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
@@ -38,25 +70,23 @@ def _is_jpeg4py_usable() -> bool:
             tmp_file.write(minimal_jpeg)
             tmp_path = tmp_file.name
 
+        jpeg_obj = None
         try:
-            result = jpeg4py.JPEG(tmp_path).decode()
+            jpeg_obj = jpeg4py.JPEG(tmp_path)
+            result = jpeg_obj.decode()
             del result
             return True
-        except (AttributeError, OSError, ValueError) as e:
-            error_str = str(e)
-            if "decompressor" in error_str:
-                return False
-            import warnings
-
-            warnings.warn(f"jpeg4py test failed: {e}", RuntimeWarning)
+        except (AttributeError, OSError, ValueError):
             return False
         finally:
+            if jpeg_obj is not None and not hasattr(jpeg_obj, "decompressor"):
+                try:
+                    setattr(jpeg_obj, "decompressor", None)
+                except Exception:
+                    pass
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
-    except Exception as e:
-        import warnings
-
-        warnings.warn(f"jpeg4py not available: {e}", RuntimeWarning)
+    except Exception:
         return False
 
 
@@ -85,4 +115,33 @@ def _build_img_lib_available() -> list[str]:
 
 
 # For backwards compatibility - deprecated, use get_img_lib_available()
-img_lib_available = get_img_lib_available()
+class _LazyList:
+    def __init__(self, factory):
+        self._factory = factory
+        self._value: list[str] | None = None
+
+    def _get(self) -> list[str]:
+        if self._value is None:
+            self._value = list(self._factory())
+        return self._value
+
+    def __iter__(self):
+        return iter(self._get())
+
+    def __len__(self) -> int:
+        return len(self._get())
+
+    def __getitem__(self, index):
+        return self._get()[index]
+
+    def __contains__(self, item) -> bool:
+        return item in self._get()
+
+    def __repr__(self) -> str:
+        return repr(self._get())
+
+    def __getattr__(self, name: str):
+        return getattr(self._get(), name)
+
+
+img_lib_available = _LazyList(get_img_lib_available)

--- a/src/imgread_benchmark/img_libs/img_libs_pkgs.py
+++ b/src/imgread_benchmark/img_libs/img_libs_pkgs.py
@@ -1,3 +1,4 @@
+import collections.abc
 from functools import lru_cache
 from importlib.util import find_spec
 from pathlib import Path
@@ -70,20 +71,12 @@ def _is_jpeg4py_usable() -> bool:
             tmp_file.write(minimal_jpeg)
             tmp_path = tmp_file.name
 
-        jpeg_obj = None
         try:
-            jpeg_obj = jpeg4py.JPEG(tmp_path)
-            result = jpeg_obj.decode()
-            del result
+            jpeg4py.JPEG(tmp_path).decode()
             return True
         except (AttributeError, OSError, ValueError):
             return False
         finally:
-            if jpeg_obj is not None and not hasattr(jpeg_obj, "decompressor"):
-                try:
-                    setattr(jpeg_obj, "decompressor", None)
-                except Exception:
-                    pass
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
     except Exception:
@@ -115,7 +108,7 @@ def _build_img_lib_available() -> list[str]:
 
 
 # For backwards compatibility - deprecated, use get_img_lib_available()
-class _LazyList:
+class _LazyList(collections.abc.Sequence):
     def __init__(self, factory):
         self._factory = factory
         self._value: list[str] | None = None
@@ -125,17 +118,11 @@ class _LazyList:
             self._value = list(self._factory())
         return self._value
 
-    def __iter__(self):
-        return iter(self._get())
-
     def __len__(self) -> int:
         return len(self._get())
 
     def __getitem__(self, index):
         return self._get()[index]
-
-    def __contains__(self, item) -> bool:
-        return item in self._get()
 
     def __repr__(self) -> str:
         return repr(self._get())

--- a/src/imgread_benchmark/read_img.py
+++ b/src/imgread_benchmark/read_img.py
@@ -46,10 +46,6 @@ def get_img_libs() -> dict:
     return {lib: load_lib(lib) for lib in get_img_lib_available()}
 
 
-# For backwards compatibility
-img_libs = get_img_libs()
-
-
 def get_func_dict(
     func_name: str, func_dict: dict[str, Any]
 ) -> dict[str, Callable[[str], Any]]:
@@ -88,8 +84,47 @@ def get_read_img_version() -> Dict[str, str]:
     }
 
 
-# For backwards compatibility
-read_img = get_read_img()
-read_img_pil = get_read_img_pil()
-read_img_ndarray = get_read_img_ndarray()
-read_img_version = get_read_img_version()
+class _LazyMapping:
+    def __init__(self, factory: Callable[[], Dict[str, Any]]):
+        self._factory = factory
+        self._value: Dict[str, Any] | None = None
+
+    def _get(self) -> Dict[str, Any]:
+        if self._value is None:
+            self._value = self._factory()
+        return self._value
+
+    def __getitem__(self, key: str) -> Any:
+        return self._get()[key]
+
+    def __iter__(self):
+        return iter(self._get())
+
+    def __len__(self) -> int:
+        return len(self._get())
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._get()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._get().get(key, default)
+
+    def keys(self):
+        return self._get().keys()
+
+    def items(self):
+        return self._get().items()
+
+    def values(self):
+        return self._get().values()
+
+    def __repr__(self) -> str:
+        return repr(self._get())
+
+
+# For backwards compatibility (lazy)
+img_libs = _LazyMapping(get_img_libs)
+read_img = _LazyMapping(get_read_img)
+read_img_pil = _LazyMapping(get_read_img_pil)
+read_img_ndarray = _LazyMapping(get_read_img_ndarray)
+read_img_version = _LazyMapping(get_read_img_version)

--- a/src/imgread_benchmark/read_img.py
+++ b/src/imgread_benchmark/read_img.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import importlib
-from functools import wraps
+from functools import lru_cache, wraps
 from importlib.metadata import version as pkg_version
 from typing import Any, Callable, Dict
 
@@ -11,7 +11,7 @@ from numpy import ndarray
 from PIL import Image
 from rich.console import Console
 
-from .img_libs.img_libs_pkgs import img_lib_available, lib_to_package
+from .img_libs.img_libs_pkgs import lib_to_package, get_img_lib_available
 
 console = Console()
 
@@ -40,11 +40,14 @@ def load_lib(
     return importlib.import_module(f"{module_name}.{lib_name}")
 
 
-img_libs = {}
+@lru_cache(maxsize=1)
+def get_img_libs() -> dict:
+    """Get loaded image libraries (lazy, cached)."""
+    return {lib: load_lib(lib) for lib in get_img_lib_available()}
 
 
-for img_lib in img_lib_available:
-    img_libs[img_lib] = load_lib(img_lib)
+# For backwards compatibility
+img_libs = get_img_libs()
 
 
 def get_func_dict(
@@ -53,18 +56,40 @@ def get_func_dict(
     """Return dict lib_name: func for given func_name"""
     return {
         lib_name: graceful_degradation(func)
-        for lib_name in img_lib_available
+        for lib_name in get_img_lib_available()
         if (func := getattr(func_dict[lib_name], func_name, None)) is not None
     }
 
 
-read_img: Dict[str, Callable[[str], Any]] = get_func_dict("read_img", img_libs)
-read_img_pil: Dict[str, Callable[[str], Image.Image]] = get_func_dict(
-    "read_img_pil", img_libs
-)
-read_img_ndarray: Dict[str, Callable[[str], ndarray]] = get_func_dict(
-    "read_img_ndarray", img_libs
-)
-read_img_version: Dict[str, str] = {
-    lib_name: pkg_version(lib_to_package[lib_name]) for lib_name in img_lib_available
-}
+@lru_cache(maxsize=1)
+def get_read_img() -> Dict[str, Callable[[str], Any]]:
+    """Get read_img function dict (lazy, cached)."""
+    return get_func_dict("read_img", get_img_libs())
+
+
+@lru_cache(maxsize=1)
+def get_read_img_pil() -> Dict[str, Callable[[str], Image.Image]]:
+    """Get read_img_pil function dict (lazy, cached)."""
+    return get_func_dict("read_img_pil", get_img_libs())
+
+
+@lru_cache(maxsize=1)
+def get_read_img_ndarray() -> Dict[str, Callable[[str], ndarray]]:
+    """Get read_img_ndarray function dict (lazy, cached)."""
+    return get_func_dict("read_img_ndarray", get_img_libs())
+
+
+@lru_cache(maxsize=1)
+def get_read_img_version() -> Dict[str, str]:
+    """Get version dict for image libraries (lazy, cached)."""
+    return {
+        lib_name: pkg_version(lib_to_package[lib_name])
+        for lib_name in get_img_lib_available()
+    }
+
+
+# For backwards compatibility
+read_img = get_read_img()
+read_img_pil = get_read_img_pil()
+read_img_ndarray = get_read_img_ndarray()
+read_img_version = get_read_img_version()

--- a/src/imgread_benchmark/read_img.py
+++ b/src/imgread_benchmark/read_img.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import collections.abc
 from functools import lru_cache, wraps
 from importlib.metadata import version as pkg_version
 from typing import Any, Callable, Dict
@@ -84,7 +85,7 @@ def get_read_img_version() -> Dict[str, str]:
     }
 
 
-class _LazyMapping:
+class _LazyMapping(collections.abc.Mapping):
     def __init__(self, factory: Callable[[], Dict[str, Any]]):
         self._factory = factory
         self._value: Dict[str, Any] | None = None
@@ -102,21 +103,6 @@ class _LazyMapping:
 
     def __len__(self) -> int:
         return len(self._get())
-
-    def __contains__(self, key: object) -> bool:
-        return key in self._get()
-
-    def get(self, key: str, default: Any = None) -> Any:
-        return self._get().get(key, default)
-
-    def keys(self):
-        return self._get().keys()
-
-    def items(self):
-        return self._get().items()
-
-    def values(self):
-        return self._get().values()
 
     def __repr__(self) -> str:
         return repr(self._get())

--- a/tests/test_benchmark_lazy.py
+++ b/tests/test_benchmark_lazy.py
@@ -1,0 +1,24 @@
+from imgread_benchmark import benchmark as benchmark_mod
+
+
+def test_get_read_to_format_returns_dicts():
+    read_to_format = benchmark_mod._get_read_to_format()
+    assert isinstance(read_to_format["def"], dict)
+    assert isinstance(read_to_format["pil"], dict)
+    assert isinstance(read_to_format["np"], dict)
+
+
+def test_benchmark_img_read_with_dummy_funcs():
+    def _dummy_reader(_path: str) -> str:
+        return "ok"
+
+    bench = benchmark_mod.BenchmarkImgRead(
+        filenames=["/tmp/not_used.jpg"],
+        func_dict={"dummy": _dummy_reader},
+        target_format="def",
+        num_repeats=1,
+        clear_progress=True,
+    )
+
+    assert bench.func_dict["dummy"]("/tmp/x.jpg") == "ok"
+    assert "dummy" in bench.func_names

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -62,10 +62,11 @@ def test_dataset_provider_is_abstract():
 
 
 def test_download_skips_if_exists(tmp_path):
-    """Test that download is skipped if the sentinel file exists."""
+    """Test that download is skipped if the sentinel file and expected directory exist."""
     provider = MockDataset(root_dir=tmp_path)
-    # Create a fake sentinel file
+    # Create a fake sentinel file AND expected directory
     (provider.dataset_dir / ".ready").touch()
+    (provider.dataset_dir / "full").mkdir()
 
     with patch("requests.get") as mock_get:
         provider.download("full")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -110,3 +110,27 @@ def test_extract_blocks_path_traversal(tmp_path):
     finally:
         if evil_path.exists():
             evil_path.unlink()
+
+
+def test_datasets_without_img_libs(monkeypatch):
+    """Test that dataset providers work without image libraries."""
+    import builtins
+
+    # Block all image library imports
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name in ["jpeg4py", "cv2", "skimage", "imageio"]:
+            raise ImportError(f"{name} blocked for test")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    from imgread_benchmark.datasets import ImagenetteProvider
+
+    provider = ImagenetteProvider()
+    assert provider.name == "imagenette"
+    assert provider.default_size == "full"
+
+    url = provider.get_url("160")
+    assert "imagenette2-160" in url

--- a/tests/test_img_libs_pkgs.py
+++ b/tests/test_img_libs_pkgs.py
@@ -4,7 +4,31 @@ import importlib.util
 import sys
 import types
 
-import imgread_benchmark.img_libs.img_libs_pkgs as img_libs_pkgs
+
+def load_img_libs_pkgs(
+    monkeypatch, find_library_result="libjpeg", jpeg4py_module=None
+):
+    import ctypes.util
+
+    real_find_spec = importlib.util.find_spec
+
+    monkeypatch.setattr(
+        ctypes.util, "find_library", lambda name: find_library_result
+    )
+    sys.modules.pop("jpeg4py", None)
+    sys.modules.pop("jpeg4py._py", None)
+    sys.modules.pop("imgread_benchmark.img_libs.img_libs_pkgs", None)
+    if jpeg4py_module is not None:
+        def fake_find_spec(name):
+            if name == "jpeg4py":
+                return object()
+            return real_find_spec(name)
+
+        monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+        monkeypatch.setitem(sys.modules, "jpeg4py", jpeg4py_module)
+    import imgread_benchmark.img_libs.img_libs_pkgs as img_libs_pkgs
+
+    return img_libs_pkgs
 
 
 def test_img_lib_available_skips_broken_jpeg4py(monkeypatch):
@@ -24,6 +48,7 @@ def test_img_lib_available_skips_broken_jpeg4py(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
+    img_libs_pkgs = load_img_libs_pkgs(monkeypatch)
     reloaded = importlib.reload(img_libs_pkgs)
 
     assert "jpeg4py" not in reloaded.img_lib_available
@@ -44,8 +69,12 @@ def test_is_jpeg4py_usable_true(monkeypatch):
 
     module = types.ModuleType("jpeg4py")
     setattr(module, "JPEG", FakeJPEG)
-    monkeypatch.setitem(sys.modules, "jpeg4py", module)
+    img_libs_pkgs = load_img_libs_pkgs(
+        monkeypatch, jpeg4py_module=module
+    )
 
+    assert img_libs_pkgs._is_jpeg4py_usable() is True
+    decode_count[0] = 0
     assert img_libs_pkgs._is_jpeg4py_usable() is True
     assert decode_count[0] == 1
     assert isinstance(path_holder[0], str)
@@ -61,9 +90,31 @@ def test_is_jpeg4py_usable_false_on_decode_error(monkeypatch):
 
     module = types.ModuleType("jpeg4py")
     setattr(module, "JPEG", FakeJPEG)
-    monkeypatch.setitem(sys.modules, "jpeg4py", module)
+    img_libs_pkgs = load_img_libs_pkgs(
+        monkeypatch, jpeg4py_module=module
+    )
 
     assert img_libs_pkgs._is_jpeg4py_usable() is False
+
+
+def test_is_jpeg4py_usable_false_without_libjpeg(monkeypatch):
+    decode_count = [0]
+
+    class FakeJPEG:
+        def __init__(self, path):
+            pass
+
+        def decode(self):
+            decode_count[0] += 1
+            return b"ok"
+
+    module = types.ModuleType("jpeg4py")
+    setattr(module, "JPEG", FakeJPEG)
+    img_libs_pkgs = load_img_libs_pkgs(
+        monkeypatch, find_library_result=None, jpeg4py_module=module
+    )
+    assert img_libs_pkgs._is_jpeg4py_usable() is False
+    assert decode_count[0] == 0
 
 
 def test_get_img_lib_available():

--- a/tests/test_img_libs_pkgs.py
+++ b/tests/test_img_libs_pkgs.py
@@ -64,3 +64,22 @@ def test_is_jpeg4py_usable_false_on_decode_error(monkeypatch):
     monkeypatch.setitem(sys.modules, "jpeg4py", module)
 
     assert img_libs_pkgs._is_jpeg4py_usable() is False
+
+
+def test_get_img_lib_available():
+    """Test get_img_lib_available function."""
+    from imgread_benchmark.img_libs.img_libs_pkgs import get_img_lib_available
+
+    libs = get_img_lib_available()
+    assert isinstance(libs, list)
+    # PIL should always be available (it's a required dependency)
+    assert "PIL" in libs
+
+
+def test_get_img_lib_available_cached():
+    """Test that get_img_lib_available is cached."""
+    from imgread_benchmark.img_libs.img_libs_pkgs import get_img_lib_available
+
+    libs1 = get_img_lib_available()
+    libs2 = get_img_lib_available()
+    assert libs1 is libs2

--- a/tests/test_img_libs_pkgs.py
+++ b/tests/test_img_libs_pkgs.py
@@ -5,20 +5,17 @@ import sys
 import types
 
 
-def load_img_libs_pkgs(
-    monkeypatch, find_library_result="libjpeg", jpeg4py_module=None
-):
+def load_img_libs_pkgs(monkeypatch, find_library_result="libjpeg", jpeg4py_module=None):
     import ctypes.util
 
     real_find_spec = importlib.util.find_spec
 
-    monkeypatch.setattr(
-        ctypes.util, "find_library", lambda name: find_library_result
-    )
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: find_library_result)
     sys.modules.pop("jpeg4py", None)
     sys.modules.pop("jpeg4py._py", None)
     sys.modules.pop("imgread_benchmark.img_libs.img_libs_pkgs", None)
     if jpeg4py_module is not None:
+
         def fake_find_spec(name):
             if name == "jpeg4py":
                 return object()
@@ -69,9 +66,7 @@ def test_is_jpeg4py_usable_true(monkeypatch):
 
     module = types.ModuleType("jpeg4py")
     setattr(module, "JPEG", FakeJPEG)
-    img_libs_pkgs = load_img_libs_pkgs(
-        monkeypatch, jpeg4py_module=module
-    )
+    img_libs_pkgs = load_img_libs_pkgs(monkeypatch, jpeg4py_module=module)
 
     assert img_libs_pkgs._is_jpeg4py_usable() is True
     decode_count[0] = 0
@@ -90,9 +85,7 @@ def test_is_jpeg4py_usable_false_on_decode_error(monkeypatch):
 
     module = types.ModuleType("jpeg4py")
     setattr(module, "JPEG", FakeJPEG)
-    img_libs_pkgs = load_img_libs_pkgs(
-        monkeypatch, jpeg4py_module=module
-    )
+    img_libs_pkgs = load_img_libs_pkgs(monkeypatch, jpeg4py_module=module)
 
     assert img_libs_pkgs._is_jpeg4py_usable() is False
 
@@ -134,3 +127,11 @@ def test_get_img_lib_available_cached():
     libs1 = get_img_lib_available()
     libs2 = get_img_lib_available()
     assert libs1 is libs2
+
+
+def test_lazy_list_is_sequence():
+    import collections.abc
+
+    from imgread_benchmark.img_libs.img_libs_pkgs import img_lib_available
+
+    assert isinstance(img_lib_available, collections.abc.Sequence)

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,55 @@
+"""Test that data loading doesn't import image libraries."""
+
+
+def test_data_download_no_img_libs_import(monkeypatch):
+    """Test that imgread_data doesn't import image libraries."""
+    import builtins
+
+    # Track if jpeg4py was imported
+    jpeg4py_imported = [False]
+
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "jpeg4py" or name.startswith("jpeg4py."):
+            jpeg4py_imported[0] = True
+            raise ImportError("jpeg4py blocked for test")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    # Import and use data download module
+    from imgread_benchmark.cl_data import DATASET_PROVIDERS
+
+    # Should not have imported jpeg4py
+    assert not jpeg4py_imported[0], "jpeg4py should not be imported for data download"
+
+    # Verify datasets are accessible
+    assert "imagenette" in DATASET_PROVIDERS
+
+
+def test_lazy_img_lib_detection():
+    """Test that image library detection is lazy."""
+    # This should not import jpeg4py
+    from imgread_benchmark.img_libs.img_libs_pkgs import get_img_lib_available
+
+    # First call should work
+    libs = get_img_lib_available()
+    assert isinstance(libs, list)
+
+    # Second call should be cached
+    libs2 = get_img_lib_available()
+    assert libs is libs2  # Same object (cached)
+
+
+def test_package_lazy_imports():
+    """Test that package imports are lazy."""
+    import imgread_benchmark
+
+    # These should not trigger benchmarking imports yet
+    assert hasattr(imgread_benchmark, "__getattr__")
+
+    # Accessing BenchmarkImgRead should trigger import
+    from imgread_benchmark import BenchmarkImgRead
+
+    assert BenchmarkImgRead is not None

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -53,3 +53,15 @@ def test_package_lazy_imports():
     from imgread_benchmark import BenchmarkImgRead
 
     assert BenchmarkImgRead is not None
+
+
+def test_lazy_mapping_is_mapping():
+    import collections.abc
+
+    from imgread_benchmark import read_img as read_img_mod
+
+    assert isinstance(read_img_mod.img_libs, collections.abc.Mapping)
+    assert isinstance(read_img_mod.read_img, collections.abc.Mapping)
+    assert isinstance(read_img_mod.read_img_pil, collections.abc.Mapping)
+    assert isinstance(read_img_mod.read_img_ndarray, collections.abc.Mapping)
+    assert isinstance(read_img_mod.read_img_version, collections.abc.Mapping)


### PR DESCRIPTION
Convert module-level imports to lazy loading to improve startup performance and prevent premature initialization of image processing libraries.

- Replace direct imports with factory functions in benchmark.py
- Introduce LazyMapping and LazyList wrapper classes
- Add robust checks for jpeg4py library availability
- Patch jpeg4py.__del__ to prevent AttributeError on cleanup
- Add comprehensive tests for lazy loading behavior