### PR TITLE
Wrapper_for_libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,38 +25,73 @@ uv run imgread_benchmark data imagenette --size 160
 
 Datasets are stored in the `.data/` directory by default.
 
-## Plugin Backends (No Repo Changes Needed)
+## Add External Backend Plugin (No Repo Code Changes)
 
-`imgread_benchmark` supports external image backends via Python entry points.
-After you install a plugin package into the same environment, it is discovered
-automatically by `imgread_benchmark libs`.
+`imgread_benchmark` discovers external backends via Python entry points.
+You do not need to modify this repository to add your backend.
 
-Entry point group:
+1. Create a plugin package (local or published) with an adapter module.
+2. Expose your backend via entry point group `imgread_benchmark.img_libs`.
+3. Install the plugin package into the same environment as `imgread_benchmark`.
+4. Verify with `imgread_benchmark libs`.
 
-- `imgread_benchmark.img_libs`
+Minimal adapter example (`my_backend_plugin.py`):
 
-Example in plugin package `pyproject.toml`:
+```python
+from PIL import Image
+import numpy as np
 
-```toml
-[project.entry-points."imgread_benchmark.img_libs"]
-imgread_rs = "imgread_rs_plugin:adapter"
+
+def read_img(path: str):
+    return read_img_ndarray(path)
+
+
+def read_img_pil(path: str) -> Image.Image:
+    with Image.open(path) as img:
+        return img.convert("RGB")
+
+
+def read_img_ndarray(path: str) -> np.ndarray:
+    return np.asarray(read_img_pil(path))
+
+
+def is_available() -> bool:
+    return True
 ```
 
-The entry point value should resolve to an adapter object/module that can expose
-any of these callables (partial adapters are allowed):
+Plugin `pyproject.toml`:
 
-- `read_img(path: str)`
-- `read_img_pil(path: str)`
-- `read_img_ndarray(path: str)`
+```toml
+[project]
+name = "my-backend-plugin"
+version = "0.1.0"
+dependencies = ["imgread_benchmark", "pillow", "numpy"]
 
-Optional:
+[project.entry-points."imgread_benchmark.img_libs"]
+my_backend = "my_backend_plugin"
+```
 
-- `is_available() -> bool` for runtime checks (return `False` to hide backend)
+Install plugin into current environment:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv pip install -e /path/to/my-backend-plugin
+```
+
+Verify discovery and run benchmark:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run imgread_benchmark libs
+UV_CACHE_DIR=.uv-cache uv run imgread_benchmark /path/to/images -l my_backend
+```
 
 Notes:
 
-- If a plugin name conflicts with a built-in backend name, the built-in backend wins.
-- Built-in backends are listed first; plugin backends are appended after discovery.
+- `read_img`, `read_img_pil`, and `read_img_ndarray` are optional individually.
+- For `-t def`, backend should provide `read_img`.
+- For `-t pil`, backend should provide `read_img_pil`.
+- For `-t np`, backend should provide `read_img_ndarray`.
+- If plugin name conflicts with a built-in backend name, built-in backend wins.
+- Built-in backends are listed first; additional and plugin backends are appended.
 
 ## Install Local Rust/PyO3 Backend
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # imgread_benchmark
 Benchmark for read images with different libs.
 
+## List Available Image Libraries
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run imgread_benchmark libs
+```
+
 ## Dataset Management
 
 You can download standard datasets for benchmarking using the `imgread_benchmark data` subcommand.
@@ -18,3 +24,53 @@ uv run imgread_benchmark data imagenette --size 160
 ```
 
 Datasets are stored in the `.data/` directory by default.
+
+## Plugin Backends (No Repo Changes Needed)
+
+`imgread_benchmark` supports external image backends via Python entry points.
+After you install a plugin package into the same environment, it is discovered
+automatically by `imgread_benchmark libs`.
+
+Entry point group:
+
+- `imgread_benchmark.img_libs`
+
+Example in plugin package `pyproject.toml`:
+
+```toml
+[project.entry-points."imgread_benchmark.img_libs"]
+imgread_rs = "imgread_rs_plugin:adapter"
+```
+
+The entry point value should resolve to an adapter object/module that can expose
+any of these callables (partial adapters are allowed):
+
+- `read_img(path: str)`
+- `read_img_pil(path: str)`
+- `read_img_ndarray(path: str)`
+
+Optional:
+
+- `is_available() -> bool` for runtime checks (return `False` to hide backend)
+
+Notes:
+
+- If a plugin name conflicts with a built-in backend name, the built-in backend wins.
+- Built-in backends are listed first; plugin backends are appended after discovery.
+
+## Install Local Rust/PyO3 Backend
+
+Example installing a local backend crate into this project environment:
+
+```bash
+env -u CONDA_PREFIX \
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+  UV_CACHE_DIR=.uv-cache \
+  /path/to/maturin develop --manifest-path /path/to/backend/Cargo.toml --uv
+```
+
+Then verify:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run imgread_benchmark libs
+```

--- a/src/imgread_benchmark/argparse_compat.py
+++ b/src/imgread_benchmark/argparse_compat.py
@@ -1,0 +1,60 @@
+from dataclasses import MISSING, field as dataclass_field
+import sys
+from typing import Any
+
+from argparsecfg.core import add_argument_metadata
+
+
+def field_argument(
+    *name_or_flags: str,
+    default: Any = MISSING,
+    default_factory: Any = MISSING,
+    init: bool = True,
+    repr: bool = True,
+    hash: bool | None = None,
+    compare: bool = True,
+    metadata: dict[str, Any] | None = None,
+    kw_only: Any = MISSING,
+    flag: str | None = None,
+    action: str | None = None,
+    nargs: int | str | None = None,
+    const: Any = None,
+    type: str | type | None = None,
+    choices: list[Any] | tuple[Any, ...] | None = None,
+    required: bool | None = None,
+    help: str | None = None,
+    metavar: str | None = None,
+    dest: str | None = None,
+    version: str | None = None,
+) -> Any:
+    """Drop-in replacement for argparsecfg.field_argument on Python 3.14+."""
+    del version
+    arg_metadata = add_argument_metadata(
+        *name_or_flags,
+        flag=flag,
+        action=action,
+        nargs=nargs,
+        const=const,
+        type=type,
+        choices=choices,
+        required=required,
+        help=help,
+        metavar=metavar,
+        dest=dest,
+    )
+    field_kwargs = {
+        "default": default,
+        "default_factory": default_factory,
+        "init": init,
+        "repr": repr,
+        "hash": hash,
+        "compare": compare,
+    }
+    if sys.version_info.minor >= 10:  # pragma: no branch
+        field_kwargs["kw_only"] = kw_only
+
+    if metadata is not None:
+        arg_metadata.update(metadata)
+    field_kwargs["metadata"] = arg_metadata
+
+    return dataclass_field(**field_kwargs)

--- a/src/imgread_benchmark/cl_app.py
+++ b/src/imgread_benchmark/cl_app.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 import sys
-from argparsecfg import field_argument
 from argparsecfg.app import app
 from dataclasses import dataclass
+from .argparse_compat import field_argument
 from .benchmark import BenchmarkImgRead
 from .get_img_filenames import get_img_filenames
 

--- a/src/imgread_benchmark/cl_data.py
+++ b/src/imgread_benchmark/cl_data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from argparsecfg import field_argument
 from argparsecfg.app import app
+from .argparse_compat import field_argument
 from .datasets import DatasetProvider, ImagenetteProvider
 
 DATASET_PROVIDERS: dict[str, type[DatasetProvider]] = {

--- a/src/imgread_benchmark/cl_versions.py
+++ b/src/imgread_benchmark/cl_versions.py
@@ -1,7 +1,7 @@
-from argparsecfg import field_argument
 from argparsecfg.app import app
 from dataclasses import dataclass
 
+from .argparse_compat import field_argument
 from .read_img import get_img_libs, get_read_img_version
 from .version import __version__
 

--- a/src/imgread_benchmark/cli.py
+++ b/src/imgread_benchmark/cli.py
@@ -322,7 +322,7 @@ def _build_cli() -> App:
                 multiprocessing=cfg.multiprocessing,
                 num_workers=num_workers,
             )
-        except (PermissionError, RuntimeError) as exc:
+        except (PermissionError, RuntimeError, OSError) as exc:
             if not cfg.multiprocessing:
                 raise
             _print_multiprocessing_start_error(exc)

--- a/src/imgread_benchmark/cli.py
+++ b/src/imgread_benchmark/cli.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import Sequence, Union
 
-from argparsecfg import field_argument
 from argparsecfg.app import App
+from .argparse_compat import field_argument
 
 _KNOWN_COMMANDS = {"benchmark", "libs", "data"}
 
@@ -162,13 +162,21 @@ def _build_cli() -> App:
             help="Format for read image to: default: 'def', Pil: 'pil', or Numpy: 'np'.",
         )
         all: bool = field_argument(
-            "-A", default=False, action="store_true", help="Use all images from folder"
+            "-A",
+            default=False,
+            action="store_true",
+            help="Use all images from folder",
         )
         img_lib: str = field_argument(
-            "-l", "--img_lib", default=None, help="Image lib to test"
+            "-l",
+            "--img_lib",
+            default=None,
+            help="Image lib to test",
         )
         exclude: str = field_argument(
-            "-x", default=None, help="Image lib exclude from test"
+            "-x",
+            default=None,
+            help="Image lib exclude from test",
         )
         multiprocessing: bool = field_argument(
             "-m",
@@ -176,7 +184,10 @@ def _build_cli() -> App:
             action="store_true",
             help="use multiprocessing, default=False",
         )
-        nw: int = field_argument(default=None, help="num workers, if 0 -> use all cpus")
+        nw: int = field_argument(
+            default=None,
+            help="num workers, if 0 -> use all cpus",
+        )
 
     def benchmark(cfg: BenchmarkConfig) -> None:
         from pathlib import Path as StdLibPath

--- a/src/imgread_benchmark/cli.py
+++ b/src/imgread_benchmark/cli.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Sequence, Union
+from functools import partial
+from typing import Callable, Sequence, Union
 
 from argparsecfg.app import App
 from .argparse_compat import field_argument
@@ -8,18 +9,33 @@ _KNOWN_COMMANDS = {"benchmark", "libs", "data"}
 
 _BENCHMARK_FLAG_ALLOWLIST = {
     "-n",
+    "--num_samples",
     "-t",
+    "--to",
     "-A",
+    "--all",
     "-l",
     "--img_lib",
     "-x",
+    "--exclude",
     "-m",
+    "--multiprocessing",
     "--nw",
 }
 
 _ROOT_ONLY_FLAGS = {"-h", "--help", "-V", "--version"}
 
-_FLAGS_WITH_VALUES = {"-n", "-t", "-l", "--img_lib", "-x", "--nw"}
+_FLAGS_WITH_VALUES = {
+    "-n",
+    "--num_samples",
+    "-t",
+    "--to",
+    "-l",
+    "--img_lib",
+    "-x",
+    "--exclude",
+    "--nw",
+}
 
 
 def _normalize_argv(argv: Sequence[str]) -> list[str]:
@@ -74,6 +90,58 @@ def _normalize_argv(argv: Sequence[str]) -> list[str]:
 
     # Positional argument - inject "benchmark"
     return ["benchmark", *argv]
+
+
+def _select_funcs_for_run(
+    func_dict: dict[str, Callable[[str], object]],
+    func_name: str | None,
+    exclude: str | None,
+) -> dict[str, Callable[[str], object]]:
+    if func_name:
+        if func_name in func_dict:
+            return {func_name: func_dict[func_name]}
+        return {}
+    if exclude:
+        return {name: func for name, func in func_dict.items() if name != exclude}
+    return dict(func_dict)
+
+
+def _get_multiprocessing_compat_errors(
+    func_dict: dict[str, Callable[[str], object]],
+    func_name: str | None,
+    exclude: str | None,
+) -> list[tuple[str, Exception]]:
+    from benchmark_utils.benchmark import try_run
+    from multiprocessing.reduction import ForkingPickler
+
+    errors: list[tuple[str, Exception]] = []
+    for name, func in _select_funcs_for_run(func_dict, func_name, exclude).items():
+        try:
+            ForkingPickler.dumps(partial(try_run, func))
+        except Exception as exc:  # pragma: no cover - exercised via CLI tests
+            errors.append((name, exc))
+    return errors
+
+
+def _probe_multiprocessing_workers(num_workers: int | None) -> None:
+    from multiprocessing import Pool, cpu_count
+
+    workers = cpu_count() if num_workers is None else num_workers
+    if workers <= 0:
+        workers = cpu_count()
+    with Pool(workers) as pool:
+        pool.map(int, [1])
+
+
+def _print_multiprocessing_start_error(exc: Exception) -> None:
+    import sys as _sys
+
+    print("Error: failed to start multiprocessing workers.", file=_sys.stderr)
+    print(f"Detail: {type(exc).__name__}: {exc}", file=_sys.stderr)
+    print(
+        "Try running without -m/--multiprocessing or adjust environment multiprocessing permissions.",
+        file=_sys.stderr,
+    )
 
 
 @dataclass
@@ -198,9 +266,44 @@ def _build_cli() -> App:
         if not StdLibPath(cfg.img_path).exists():
             print(f"Error: Img dir '{cfg.img_path}' does not exist!", file=_sys.stderr)
             raise SystemExit(1)
+        if cfg.nw is not None and cfg.nw < 0:
+            print("Error: --nw must be a non-negative integer.", file=_sys.stderr)
+            raise SystemExit(2)
+        num_workers = None if cfg.nw == 0 else cfg.nw
         if cfg.all:
             cfg.num_samples = 0
         filenames = get_img_filenames(cfg.img_path, num_samples=cfg.num_samples)
+
+        from .benchmark import BenchmarkImgRead
+
+        bench = BenchmarkImgRead(filenames=filenames, target_format=cfg.to)
+        if cfg.multiprocessing:
+            compat_errors = _get_multiprocessing_compat_errors(
+                bench.func_dict,
+                cfg.img_lib,
+                cfg.exclude,
+            )
+            if compat_errors:
+                print(
+                    "Error: selected image readers are not compatible with multiprocessing serialization.",
+                    file=_sys.stderr,
+                )
+                for name, exc in compat_errors:
+                    print(
+                        f"  - {name}: {type(exc).__name__}: {exc}",
+                        file=_sys.stderr,
+                    )
+                print(
+                    "Try running without -m/--multiprocessing or use pickle-safe backend callables.",
+                    file=_sys.stderr,
+                )
+                raise SystemExit(2)
+            try:
+                _probe_multiprocessing_workers(num_workers)
+            except (PermissionError, RuntimeError, OSError) as exc:
+                _print_multiprocessing_start_error(exc)
+                raise SystemExit(2) from exc
+
         if len(filenames) < cfg.num_samples:
             print(
                 f"! Number of files in {cfg.img_path}: {len(filenames)} less than num_samples: {cfg.num_samples}"
@@ -212,15 +315,18 @@ def _build_cli() -> App:
         else:
             print(f"{len(filenames)} images.")
 
-        from .benchmark import BenchmarkImgRead
-
-        bench = BenchmarkImgRead(filenames=filenames, target_format=cfg.to)
-        bench.run(
-            func_name=cfg.img_lib,
-            exclude=cfg.exclude,
-            multiprocessing=cfg.multiprocessing,
-            num_workers=cfg.nw,
-        )
+        try:
+            bench.run(
+                func_name=cfg.img_lib,
+                exclude=cfg.exclude,
+                multiprocessing=cfg.multiprocessing,
+                num_workers=num_workers,
+            )
+        except (PermissionError, RuntimeError) as exc:
+            if not cfg.multiprocessing:
+                raise
+            _print_multiprocessing_start_error(exc)
+            raise SystemExit(2) from exc
 
     cli.command(benchmark)
     return cli

--- a/src/imgread_benchmark/img_libs/img_libs_pkgs.py
+++ b/src/imgread_benchmark/img_libs/img_libs_pkgs.py
@@ -14,6 +14,8 @@ lib_to_package = {
     "imageio": "imageio",  # conda
     "imread": "imread",  # conda
     "kornia": "kornia",
+    "local_rs": "local_rs",
+    "imgread_rs": "imgread-rs",
     # "pyvips": "pyvips",  # conda
     "torchvision": "torchvision",
 }

--- a/src/imgread_benchmark/img_libs/img_libs_pkgs.py
+++ b/src/imgread_benchmark/img_libs/img_libs_pkgs.py
@@ -1,11 +1,15 @@
 import collections.abc
 from functools import lru_cache
+from importlib.metadata import EntryPoint, entry_points
 from importlib.util import find_spec
 from pathlib import Path
 import tempfile
 from ctypes.util import find_library
+from typing import Any
 
-lib_to_package = {
+ENTRY_POINT_GROUP = "imgread_benchmark.img_libs"
+
+_BUILTIN_LIB_TO_PACKAGE = {
     "PIL": "pillow",
     "accimage": "accimage",  # only conda
     "jpeg4py": "jpeg4py",
@@ -19,6 +23,9 @@ lib_to_package = {
     # "pyvips": "pyvips",  # conda
     "torchvision": "torchvision",
 }
+
+# Backwards compatibility for code importing this constant directly.
+lib_to_package = dict(_BUILTIN_LIB_TO_PACKAGE)
 
 
 def _has_jpeg_turbo() -> bool:
@@ -85,27 +92,106 @@ def _is_jpeg4py_usable() -> bool:
         return False
 
 
+def _iter_entry_points() -> list[EntryPoint]:
+    try:
+        eps = entry_points(group=ENTRY_POINT_GROUP)
+        return list(eps)
+    except TypeError:
+        eps = entry_points()
+        return list(eps.get(ENTRY_POINT_GROUP, ()))
+    except Exception:
+        return []
+
+
+def _entry_point_module_exists(ep: EntryPoint) -> bool:
+    module = getattr(ep, "module", None)
+    if not module:
+        return True
+    try:
+        return find_spec(module) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+@lru_cache(maxsize=1)
+def get_plugin_entry_points() -> dict[str, EntryPoint]:
+    """Get discovered external plugin entry points by backend name."""
+    plugins: dict[str, EntryPoint] = {}
+    for ep in sorted(_iter_entry_points(), key=lambda item: (item.name, item.value)):
+        if ep.name in _BUILTIN_LIB_TO_PACKAGE:
+            continue
+        if ep.name in plugins:
+            continue
+        if not _entry_point_module_exists(ep):
+            continue
+        plugins[ep.name] = ep
+    return plugins
+
+
+def load_img_lib_adapter(lib_name: str) -> Any:
+    """Load built-in adapter module or external entry-point adapter."""
+    if lib_name in _BUILTIN_LIB_TO_PACKAGE:
+        import importlib
+
+        return importlib.import_module(f"imgread_benchmark.img_libs.{lib_name}")
+    ep = get_plugin_entry_points().get(lib_name)
+    if ep is None:
+        raise ModuleNotFoundError(f"Unknown image backend: {lib_name}")
+    return ep.load()
+
+
+def _plugin_is_available(ep: EntryPoint) -> bool:
+    try:
+        adapter = ep.load()
+    except Exception:
+        return False
+    is_available = getattr(adapter, "is_available", None)
+    if callable(is_available):
+        try:
+            return bool(is_available())
+        except Exception:
+            return False
+    return True
+
+
+@lru_cache(maxsize=1)
+def get_lib_package_map() -> dict[str, str]:
+    """Get backend name -> package name map for built-ins and plugins."""
+    packages = dict(_BUILTIN_LIB_TO_PACKAGE)
+    for name, ep in get_plugin_entry_points().items():
+        dist = getattr(ep, "dist", None)
+        dist_name = getattr(dist, "name", None)
+        packages[name] = dist_name or ep.module.split(".")[0]
+    return packages
+
+
 @lru_cache(maxsize=1)
 def get_img_lib_available() -> list[str]:
     """Get list of available image libraries (lazy, cached)."""
     available: list[str] = []
-    for lib_name in lib_to_package:
+    for lib_name in _BUILTIN_LIB_TO_PACKAGE:
         if find_spec(lib_name) is None:
             continue
         if lib_name == "jpeg4py" and not _is_jpeg4py_usable():
             continue
         available.append(lib_name)
+    for lib_name, ep in get_plugin_entry_points().items():
+        if _plugin_is_available(ep):
+            available.append(lib_name)
     return available
 
 
 def _build_img_lib_available() -> list[str]:
     available: list[str] = []
-    for lib_name in lib_to_package:
+    for lib_name in _BUILTIN_LIB_TO_PACKAGE:
         if find_spec(lib_name) is None:
             continue
         if lib_name == "jpeg4py" and not _is_jpeg4py_usable():
             continue
         available.append(lib_name)
+    for lib_name, ep in get_plugin_entry_points().items():
+        if _plugin_is_available(ep):
+            available.append(lib_name)
     return available
 
 

--- a/src/imgread_benchmark/img_libs/img_libs_pkgs.py
+++ b/src/imgread_benchmark/img_libs/img_libs_pkgs.py
@@ -9,7 +9,7 @@ from typing import Any
 
 ENTRY_POINT_GROUP = "imgread_benchmark.img_libs"
 
-_BUILTIN_LIB_TO_PACKAGE = {
+_CORE_BUILTIN_LIB_TO_PACKAGE = {
     "PIL": "pillow",
     "accimage": "accimage",  # only conda
     "jpeg4py": "jpeg4py",
@@ -18,14 +18,27 @@ _BUILTIN_LIB_TO_PACKAGE = {
     "imageio": "imageio",  # conda
     "imread": "imread",  # conda
     "kornia": "kornia",
-    "local_rs": "local_rs",
-    "imgread_rs": "imgread-rs",
     # "pyvips": "pyvips",  # conda
     "torchvision": "torchvision",
 }
 
+_ADDITIONAL_LIB_TO_PACKAGE = {
+    # Optional non-core backends that should be appended after core built-ins.
+    "local_rs": "local_rs",
+    "imgread_rs": "imgread-rs",
+}
+
+_BUILTIN_LIB_TO_PACKAGE = {
+    **_CORE_BUILTIN_LIB_TO_PACKAGE,
+    **_ADDITIONAL_LIB_TO_PACKAGE,
+}
+
 # Backwards compatibility for code importing this constant directly.
 lib_to_package = dict(_BUILTIN_LIB_TO_PACKAGE)
+
+
+def _iter_builtin_libs_in_order() -> tuple[str, ...]:
+    return (*_CORE_BUILTIN_LIB_TO_PACKAGE, *_ADDITIONAL_LIB_TO_PACKAGE)
 
 
 def _has_jpeg_turbo() -> bool:
@@ -169,7 +182,7 @@ def get_lib_package_map() -> dict[str, str]:
 def get_img_lib_available() -> list[str]:
     """Get list of available image libraries (lazy, cached)."""
     available: list[str] = []
-    for lib_name in _BUILTIN_LIB_TO_PACKAGE:
+    for lib_name in _iter_builtin_libs_in_order():
         if find_spec(lib_name) is None:
             continue
         if lib_name == "jpeg4py" and not _is_jpeg4py_usable():
@@ -183,7 +196,7 @@ def get_img_lib_available() -> list[str]:
 
 def _build_img_lib_available() -> list[str]:
     available: list[str] = []
-    for lib_name in _BUILTIN_LIB_TO_PACKAGE:
+    for lib_name in _iter_builtin_libs_in_order():
         if find_spec(lib_name) is None:
             continue
         if lib_name == "jpeg4py" and not _is_jpeg4py_usable():

--- a/src/imgread_benchmark/img_libs/img_libs_pkgs.py
+++ b/src/imgread_benchmark/img_libs/img_libs_pkgs.py
@@ -1,4 +1,5 @@
 import collections.abc
+import sys
 from functools import lru_cache
 from importlib.metadata import EntryPoint, entry_points
 from importlib.util import find_spec
@@ -156,7 +157,11 @@ def load_img_lib_adapter(lib_name: str) -> Any:
 def _plugin_is_available(ep: EntryPoint) -> bool:
     try:
         adapter = ep.load()
-    except Exception:
+    except Exception as exc:
+        print(
+            f"Warning: Could not load plugin entry point '{ep.name}': {exc}",
+            file=sys.stderr,
+        )
         return False
     is_available = getattr(adapter, "is_available", None)
     if callable(is_available):
@@ -181,20 +186,6 @@ def get_lib_package_map() -> dict[str, str]:
 @lru_cache(maxsize=1)
 def get_img_lib_available() -> list[str]:
     """Get list of available image libraries (lazy, cached)."""
-    available: list[str] = []
-    for lib_name in _iter_builtin_libs_in_order():
-        if find_spec(lib_name) is None:
-            continue
-        if lib_name == "jpeg4py" and not _is_jpeg4py_usable():
-            continue
-        available.append(lib_name)
-    for lib_name, ep in get_plugin_entry_points().items():
-        if _plugin_is_available(ep):
-            available.append(lib_name)
-    return available
-
-
-def _build_img_lib_available() -> list[str]:
     available: list[str] = []
     for lib_name in _iter_builtin_libs_in_order():
         if find_spec(lib_name) is None:

--- a/src/imgread_benchmark/img_libs/imgread_rs.py
+++ b/src/imgread_benchmark/img_libs/imgread_rs.py
@@ -1,0 +1,25 @@
+import numpy as np
+from PIL import Image
+
+import imgread_rs as _imgread_rs
+
+__all__ = ["read_img", "read_img_ndarray", "read_img_pil"]
+
+
+def read_img_ndarray(img_path: str) -> np.ndarray:
+    """Read image with imgread_rs, fallback to PIL until ndarray API is returned."""
+    result = _imgread_rs.load_numpy(img_path)
+    if result is not None:
+        return np.asarray(result)
+    with Image.open(img_path) as img:
+        return np.asarray(img.convert("RGB"))
+
+
+def read_img_pil(img_path: str) -> Image.Image:
+    """Read image with imgread_rs and return PIL.Image."""
+    return Image.fromarray(read_img_ndarray(img_path), mode="RGB")
+
+
+def read_img(img_path: str) -> np.ndarray:
+    """Default reader for imgread_rs backend."""
+    return read_img_ndarray(img_path)

--- a/src/imgread_benchmark/img_libs/local_rs.py
+++ b/src/imgread_benchmark/img_libs/local_rs.py
@@ -1,0 +1,24 @@
+import numpy as np
+from PIL import Image
+
+import local_rs as _local_rs
+
+__all__ = ["read_img", "read_img_ndarray", "read_img_pil"]
+
+
+def read_img_ndarray(img_path: str) -> np.ndarray:
+    """Read image from path with local_rs and return numpy array."""
+    try:
+        return np.asarray(_local_rs.open_jpeg_turbo(img_path))
+    except Exception:
+        return np.asarray(_local_rs.open_jpeg(img_path))
+
+
+def read_img_pil(img_path: str) -> Image.Image:
+    """Read image from path with local_rs and return PIL.Image."""
+    return Image.fromarray(read_img_ndarray(img_path), mode="RGB")
+
+
+def read_img(img_path: str) -> np.ndarray:
+    """Default reader for local_rs backend."""
+    return read_img_ndarray(img_path)

--- a/src/imgread_benchmark/read_img.py
+++ b/src/imgread_benchmark/read_img.py
@@ -4,47 +4,67 @@ from __future__ import annotations
 
 import importlib
 import collections.abc
-from functools import lru_cache, wraps
-from importlib.metadata import version as pkg_version
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version as pkg_version
 from typing import Any, Callable, Dict
 
 from numpy import ndarray
 from PIL import Image
 from rich.console import Console
 
-from .img_libs.img_libs_pkgs import lib_to_package, get_img_lib_available
-
 console = Console()
 
 
-def graceful_degradation(func: Callable[[str], Any]) -> Callable[[str], Any]:
-    """Decorator for graceful degradation."""
+def _img_libs_pkgs():
+    return importlib.import_module("imgread_benchmark.img_libs.img_libs_pkgs")
 
-    @wraps(func)
-    def wrapper(img_path: str, *args, **kwargs) -> Any:
+
+class _GracefulReadCallable:
+    """Pickle-safe callable wrapper with graceful error handling."""
+
+    def __init__(self, func: Callable[..., Any]):
+        self._func = func
+        self.__wrapped__ = func
+        self.__name__ = getattr(func, "__name__", self.__class__.__name__)
+        self.__qualname__ = getattr(func, "__qualname__", self.__name__)
+        self.__module__ = getattr(func, "__module__", __name__)
+        self.__doc__ = getattr(func, "__doc__")
+
+    def __call__(self, img_path: str, *args: Any, **kwargs: Any) -> Any:
         try:
-            return func(img_path, *args, **kwargs)
+            return self._func(img_path, *args, **kwargs)
         except (OSError, ValueError) as e:
             console.print(
                 f"[yellow]Warning: Error reading {img_path} with "
-                f"{func.__module__}: {e}[/yellow]"
+                f"{self._func.__module__}: {e}[/yellow]"
             )
             return None
 
-    return wrapper
+
+def graceful_degradation(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Return pickle-safe wrapper for graceful degradation."""
+    return _GracefulReadCallable(func)
 
 
 def load_lib(
     lib_name: str = "pil", module_name: str = "imgread_benchmark.img_libs"
 ) -> Any:
     """Load image lib."""
+    if module_name == "imgread_benchmark.img_libs":
+        return _img_libs_pkgs().load_img_lib_adapter(lib_name)
     return importlib.import_module(f"{module_name}.{lib_name}")
 
 
 @lru_cache(maxsize=1)
 def get_img_libs() -> dict:
     """Get loaded image libraries (lazy, cached)."""
-    return {lib: load_lib(lib) for lib in get_img_lib_available()}
+    loaded: dict[str, Any] = {}
+    for lib in _img_libs_pkgs().get_img_lib_available():
+        try:
+            loaded[lib] = load_lib(lib)
+        except Exception:
+            continue
+    return loaded
 
 
 def get_func_dict(
@@ -53,8 +73,8 @@ def get_func_dict(
     """Return dict lib_name: func for given func_name"""
     return {
         lib_name: graceful_degradation(func)
-        for lib_name in get_img_lib_available()
-        if (func := getattr(func_dict[lib_name], func_name, None)) is not None
+        for lib_name, adapter in func_dict.items()
+        if (func := getattr(adapter, func_name, None)) is not None
     }
 
 
@@ -79,21 +99,27 @@ def get_read_img_ndarray() -> Dict[str, Callable[[str], ndarray]]:
 @lru_cache(maxsize=1)
 def get_read_img_version() -> Dict[str, str]:
     """Get version dict for image libraries (lazy, cached)."""
-    return {
-        lib_name: pkg_version(lib_to_package[lib_name])
-        for lib_name in get_img_lib_available()
-    }
+    versions: Dict[str, str] = {}
+    module = _img_libs_pkgs()
+    package_map = module.get_lib_package_map()
+    for lib_name in module.get_img_lib_available():
+        package_name = package_map.get(lib_name)
+        if not package_name:
+            versions[lib_name] = "unknown"
+            continue
+        try:
+            versions[lib_name] = pkg_version(package_name)
+        except PackageNotFoundError:
+            versions[lib_name] = "unknown"
+    return versions
 
 
 class _LazyMapping(collections.abc.Mapping):
     def __init__(self, factory: Callable[[], Dict[str, Any]]):
         self._factory = factory
-        self._value: Dict[str, Any] | None = None
 
     def _get(self) -> Dict[str, Any]:
-        if self._value is None:
-            self._value = self._factory()
-        return self._value
+        return self._factory()
 
     def __getitem__(self, key: str) -> Any:
         return self._get()[key]

--- a/tests/test_benchmark_lazy.py
+++ b/tests/test_benchmark_lazy.py
@@ -1,4 +1,14 @@
+from functools import partial
+from multiprocessing.reduction import ForkingPickler
+
+from benchmark_utils.benchmark import try_run
+
 from imgread_benchmark import benchmark as benchmark_mod
+from imgread_benchmark.read_img import graceful_degradation
+
+
+def _dummy_reader_for_pickle(_path: str) -> str:
+    return "ok"
 
 
 def test_get_read_to_format_returns_dicts():
@@ -22,3 +32,9 @@ def test_benchmark_img_read_with_dummy_funcs():
 
     assert bench.func_dict["dummy"]("/tmp/x.jpg") == "ok"
     assert "dummy" in bench.func_names
+
+
+def test_graceful_degradation_wrapper_is_pickleable_for_multiprocessing():
+    wrapped = graceful_degradation(_dummy_reader_for_pickle)
+    payload = partial(try_run, wrapped)
+    ForkingPickler.dumps(payload)

--- a/tests/test_cli_unified.py
+++ b/tests/test_cli_unified.py
@@ -221,3 +221,35 @@ def test_benchmark_multiprocessing_permission_error_is_actionable(
     assert "failed to start multiprocessing workers" in captured.err
     assert "Benchmarking with images from" not in captured.out
     assert not run_called["value"]
+
+
+def test_benchmark_multiprocessing_runtime_oserror_is_actionable(
+    tmp_path, monkeypatch, capsys
+):
+    class DummyBench:
+        def __init__(self, filenames, target_format):
+            self.func_dict = {"PIL": lambda _path: None}
+
+        def run(self, **kwargs):
+            raise OSError("fork not allowed")
+
+    monkeypatch.setattr(
+        "imgread_benchmark.get_img_filenames.get_img_filenames",
+        lambda *_args, **_kwargs: [str(tmp_path / "img.jpg")],
+    )
+    monkeypatch.setattr("imgread_benchmark.benchmark.BenchmarkImgRead", DummyBench)
+    monkeypatch.setattr(
+        "imgread_benchmark.cli._get_multiprocessing_compat_errors",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "imgread_benchmark.cli._probe_multiprocessing_workers",
+        lambda *_args, **_kwargs: None,
+    )
+
+    cli = _build_cli()
+    with pytest.raises(SystemExit) as exc:
+        cli(["benchmark", str(tmp_path), "--multiprocessing"])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "failed to start multiprocessing workers" in captured.err

--- a/tests/test_cli_unified.py
+++ b/tests/test_cli_unified.py
@@ -1,4 +1,8 @@
-from imgread_benchmark.cli import _normalize_argv
+from pickle import PicklingError
+
+import pytest
+
+from imgread_benchmark.cli import _build_cli, _normalize_argv
 
 
 def test_normalize_injects_benchmark_for_path():
@@ -21,6 +25,17 @@ def test_normalize_argv_injects_benchmark_with_leading_flags():
 def test_normalize_argv_injects_benchmark_with_flag_without_value():
     argv = ["-A", "/imgs"]
     assert _normalize_argv(argv) == ["benchmark", "-A", "/imgs"]
+
+
+def test_normalize_argv_injects_benchmark_with_long_flags():
+    argv = ["--multiprocessing", "--to", "np", "/imgs"]
+    assert _normalize_argv(argv) == [
+        "benchmark",
+        "--multiprocessing",
+        "--to",
+        "np",
+        "/imgs",
+    ]
 
 
 def test_normalize_argv_keeps_root_help():
@@ -90,11 +105,6 @@ def test_cli_libs_prints_versions(monkeypatch, capsys):
     assert "PIL" in out and "10.0.0" in out
     assert "cv2" in out and "4.10.0" in out
 
-
-import pytest
-from imgread_benchmark.cli import _build_cli
-
-
 def test_benchmark_missing_path_errors_to_stderr(tmp_path, capsys):
     cli = _build_cli()
     with pytest.raises(SystemExit) as exc:
@@ -111,3 +121,103 @@ def test_data_unknown_dataset_errors_to_stderr(capsys):
     assert exc.value.code == 2
     captured = capsys.readouterr()
     assert "Unknown dataset" in captured.err
+
+
+def test_benchmark_nw_zero_means_all_cpus(tmp_path, monkeypatch):
+    calls = {}
+
+    class DummyBench:
+        def __init__(self, filenames, target_format):
+            self.func_dict = {"PIL": lambda _path: None}
+
+        def run(self, **kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.setattr(
+        "imgread_benchmark.get_img_filenames.get_img_filenames",
+        lambda *_args, **_kwargs: [str(tmp_path / "img.jpg")],
+    )
+    monkeypatch.setattr("imgread_benchmark.benchmark.BenchmarkImgRead", DummyBench)
+
+    cli = _build_cli()
+    cli(["benchmark", str(tmp_path), "--nw", "0"])
+
+    assert calls["num_workers"] is None
+
+
+def test_benchmark_negative_nw_errors(tmp_path, capsys):
+    cli = _build_cli()
+    with pytest.raises(SystemExit) as exc:
+        cli(["benchmark", str(tmp_path), "--nw", "-1"])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "--nw must be a non-negative integer" in captured.err
+
+
+def test_benchmark_multiprocessing_pickling_preflight_errors(tmp_path, monkeypatch, capsys):
+    run_called = {"value": False}
+
+    class DummyBench:
+        def __init__(self, filenames, target_format):
+            self.func_dict = {"PIL": lambda _path: None}
+
+        def run(self, **kwargs):
+            run_called["value"] = True
+
+    monkeypatch.setattr(
+        "imgread_benchmark.get_img_filenames.get_img_filenames",
+        lambda *_args, **_kwargs: [str(tmp_path / "img.jpg")],
+    )
+    monkeypatch.setattr("imgread_benchmark.benchmark.BenchmarkImgRead", DummyBench)
+    monkeypatch.setattr(
+        "imgread_benchmark.cli._get_multiprocessing_compat_errors",
+        lambda *_args, **_kwargs: [("PIL", PicklingError("not pickleable"))],
+    )
+
+    cli = _build_cli()
+    with pytest.raises(SystemExit) as exc:
+        cli(["benchmark", str(tmp_path), "--multiprocessing"])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "not compatible with multiprocessing serialization" in captured.err
+    assert not run_called["value"]
+
+
+def test_benchmark_multiprocessing_permission_error_is_actionable(
+    tmp_path, monkeypatch, capsys
+):
+    run_called = {"value": False}
+
+    class DummyBench:
+        def __init__(self, filenames, target_format):
+            self.func_dict = {"PIL": lambda _path: None}
+
+        def run(self, **kwargs):
+            run_called["value"] = True
+
+    monkeypatch.setattr(
+        "imgread_benchmark.get_img_filenames.get_img_filenames",
+        lambda *_args, **_kwargs: [str(tmp_path / "img.jpg")],
+    )
+    monkeypatch.setattr("imgread_benchmark.benchmark.BenchmarkImgRead", DummyBench)
+    monkeypatch.setattr(
+        "imgread_benchmark.cli._get_multiprocessing_compat_errors",
+        lambda *_args, **_kwargs: [],
+    )
+
+    def _raise_permission(*_args, **_kwargs):
+        raise PermissionError("semaphore blocked")
+
+    monkeypatch.setattr(
+        "imgread_benchmark.cli._probe_multiprocessing_workers",
+        _raise_permission,
+    )
+
+    cli = _build_cli()
+    with pytest.raises(SystemExit) as exc:
+        cli(["benchmark", str(tmp_path), "--multiprocessing"])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "failed to start multiprocessing workers" in captured.err
+    assert "Benchmarking with images from" not in captured.out
+    assert not run_called["value"]

--- a/tests/test_image_libs.py
+++ b/tests/test_image_libs.py
@@ -6,7 +6,7 @@ from imgread_benchmark.img_libs.img_libs_pkgs import img_lib_available, lib_to_p
 from imgread_benchmark.read_img import read_img, read_img_ndarray, read_img_pil
 
 if "torchvision" in img_lib_available:  # torchvision test separately
-    img_lib_available.pop(-1)  # pragma: no cover
+    img_lib_available.remove("torchvision")  # pragma: no cover
 
 dog = "tests/test_imgs/dog.jpg"
 

--- a/tests/test_img_libs_pkgs.py
+++ b/tests/test_img_libs_pkgs.py
@@ -135,3 +135,88 @@ def test_lazy_list_is_sequence():
     from imgread_benchmark.img_libs.img_libs_pkgs import img_lib_available
 
     assert isinstance(img_lib_available, collections.abc.Sequence)
+
+
+def test_entry_point_plugin_discovery(monkeypatch):
+    from imgread_benchmark.img_libs import img_libs_pkgs
+
+    class FakeDist:
+        name = "awesome-img-lib"
+
+    class FakeEntryPoint:
+        def __init__(self):
+            self.name = "awesome"
+            self.value = "awesome_plugin:adapter"
+            self.module = "awesome_plugin"
+            self.dist = FakeDist()
+
+        def load(self):
+            return types.SimpleNamespace(read_img=lambda _: "ok")
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name):
+        if name == "awesome_plugin":
+            return object()
+        return real_find_spec(name)
+
+    monkeypatch.setattr(img_libs_pkgs, "entry_points", lambda **kwargs: [FakeEntryPoint()])
+    monkeypatch.setattr(img_libs_pkgs, "find_spec", fake_find_spec)
+
+    img_libs_pkgs.get_plugin_entry_points.cache_clear()
+    img_libs_pkgs.get_lib_package_map.cache_clear()
+    img_libs_pkgs.get_img_lib_available.cache_clear()
+
+    plugins = img_libs_pkgs.get_plugin_entry_points()
+    assert "awesome" in plugins
+    assert img_libs_pkgs.get_lib_package_map()["awesome"] == "awesome-img-lib"
+    assert "awesome" in img_libs_pkgs.get_img_lib_available()
+
+
+def test_entry_point_collision_builtin_wins(monkeypatch):
+    from imgread_benchmark.img_libs import img_libs_pkgs
+
+    class FakeDist:
+        name = "shadow-pillow"
+
+    class FakeEntryPoint:
+        def __init__(self):
+            self.name = "PIL"
+            self.value = "shadow:adapter"
+            self.module = "shadow"
+            self.dist = FakeDist()
+
+        def load(self):
+            return types.SimpleNamespace(read_img=lambda _: "ok")
+
+    monkeypatch.setattr(img_libs_pkgs, "entry_points", lambda **kwargs: [FakeEntryPoint()])
+
+    img_libs_pkgs.get_plugin_entry_points.cache_clear()
+    img_libs_pkgs.get_lib_package_map.cache_clear()
+    img_libs_pkgs.get_img_lib_available.cache_clear()
+
+    assert "PIL" not in img_libs_pkgs.get_plugin_entry_points()
+    assert img_libs_pkgs.get_lib_package_map()["PIL"] == "pillow"
+
+
+def test_entry_point_is_available_hook(monkeypatch):
+    from imgread_benchmark.img_libs import img_libs_pkgs
+
+    class FakeEntryPoint:
+        name = "not_ready"
+        value = "not_ready:adapter"
+        module = "not_ready"
+        dist = None
+
+        def load(self):
+            return types.SimpleNamespace(is_available=lambda: False)
+
+    monkeypatch.setattr(img_libs_pkgs, "entry_points", lambda **kwargs: [FakeEntryPoint()])
+    monkeypatch.setattr(img_libs_pkgs, "find_spec", lambda _name: object())
+
+    img_libs_pkgs.get_plugin_entry_points.cache_clear()
+    img_libs_pkgs.get_lib_package_map.cache_clear()
+    img_libs_pkgs.get_img_lib_available.cache_clear()
+
+    assert "not_ready" in img_libs_pkgs.get_plugin_entry_points()
+    assert "not_ready" not in img_libs_pkgs.get_img_lib_available()

--- a/tests/test_img_libs_pkgs.py
+++ b/tests/test_img_libs_pkgs.py
@@ -242,3 +242,31 @@ def test_entry_point_is_available_hook(monkeypatch):
 
     assert "not_ready" in img_libs_pkgs.get_plugin_entry_points()
     assert "not_ready" not in img_libs_pkgs.get_img_lib_available()
+
+
+def test_entry_point_load_error_warns_to_stderr(monkeypatch, capsys):
+    from imgread_benchmark.img_libs import img_libs_pkgs
+
+    class FakeEntryPoint:
+        name = "broken"
+        value = "broken:adapter"
+        module = "broken"
+        dist = None
+
+        def load(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(img_libs_pkgs, "entry_points", lambda **kwargs: [FakeEntryPoint()])
+    monkeypatch.setattr(img_libs_pkgs, "find_spec", lambda _name: object())
+    monkeypatch.setattr(
+        img_libs_pkgs, "_iter_builtin_libs_in_order", lambda: ("PIL",)
+    )
+
+    img_libs_pkgs.get_plugin_entry_points.cache_clear()
+    img_libs_pkgs.get_lib_package_map.cache_clear()
+    img_libs_pkgs.get_img_lib_available.cache_clear()
+
+    assert "broken" in img_libs_pkgs.get_plugin_entry_points()
+    assert "broken" not in img_libs_pkgs.get_img_lib_available()
+    captured = capsys.readouterr()
+    assert "Could not load plugin entry point 'broken': boom" in captured.err

--- a/tests/test_img_libs_pkgs.py
+++ b/tests/test_img_libs_pkgs.py
@@ -129,6 +129,28 @@ def test_get_img_lib_available_cached():
     assert libs1 is libs2
 
 
+def test_additional_backends_are_appended_after_core(monkeypatch):
+    from imgread_benchmark.img_libs import img_libs_pkgs
+
+    def fake_find_spec(name):
+        if name in {"PIL", "local_rs", "imgread_rs"}:
+            return object()
+        return None
+
+    monkeypatch.setattr(img_libs_pkgs, "find_spec", fake_find_spec)
+    monkeypatch.setattr(img_libs_pkgs, "entry_points", lambda **kwargs: [])
+
+    img_libs_pkgs.get_plugin_entry_points.cache_clear()
+    img_libs_pkgs.get_lib_package_map.cache_clear()
+    img_libs_pkgs.get_img_lib_available.cache_clear()
+
+    libs = img_libs_pkgs.get_img_lib_available()
+
+    assert libs[:3] == ["PIL", "local_rs", "imgread_rs"]
+    assert "local_rs" not in img_libs_pkgs._CORE_BUILTIN_LIB_TO_PACKAGE
+    assert "local_rs" in img_libs_pkgs._ADDITIONAL_LIB_TO_PACKAGE
+
+
 def test_lazy_list_is_sequence():
     import collections.abc
 

--- a/tests/test_plugin_registry_integration.py
+++ b/tests/test_plugin_registry_integration.py
@@ -1,0 +1,78 @@
+from importlib.metadata import PackageNotFoundError
+import types
+
+
+def _clear_caches():
+    from imgread_benchmark.img_libs import img_libs_pkgs
+    from imgread_benchmark import read_img
+
+    img_libs_pkgs.get_plugin_entry_points.cache_clear()
+    img_libs_pkgs.get_lib_package_map.cache_clear()
+    img_libs_pkgs.get_img_lib_available.cache_clear()
+    read_img.get_img_libs.cache_clear()
+    read_img.get_read_img.cache_clear()
+    read_img.get_read_img_pil.cache_clear()
+    read_img.get_read_img_ndarray.cache_clear()
+    read_img.get_read_img_version.cache_clear()
+
+
+def test_plugin_adapter_loaded_and_callable(monkeypatch):
+    from imgread_benchmark.img_libs import img_libs_pkgs
+    from imgread_benchmark import read_img
+
+    class FakeDist:
+        name = "my-cool-backend"
+
+    class FakeEntryPoint:
+        name = "my_backend"
+        value = "my_backend_plugin:adapter"
+        module = "my_backend_plugin"
+        dist = FakeDist()
+
+        def load(self):
+            return types.SimpleNamespace(
+                read_img=lambda _path: "r",
+                read_img_pil=lambda _path: "p",
+                read_img_ndarray=lambda _path: "n",
+            )
+
+    real_find_spec = img_libs_pkgs.find_spec
+
+    def fake_find_spec(name):
+        if name == "my_backend_plugin":
+            return object()
+        return real_find_spec(name)
+
+    monkeypatch.setattr(img_libs_pkgs, "entry_points", lambda **kwargs: [FakeEntryPoint()])
+    monkeypatch.setattr(img_libs_pkgs, "find_spec", fake_find_spec)
+    _clear_caches()
+
+    assert "my_backend" in img_libs_pkgs.get_img_lib_available()
+    assert read_img.read_img["my_backend"]("x") == "r"
+    assert read_img.read_img_pil["my_backend"]("x") == "p"
+    assert read_img.read_img_ndarray["my_backend"]("x") == "n"
+
+
+def test_plugin_version_unknown_when_distribution_missing(monkeypatch):
+    from imgread_benchmark.img_libs import img_libs_pkgs
+    from imgread_benchmark import read_img
+
+    class FakeEntryPoint:
+        name = "no_dist_backend"
+        value = "pkgmod.sub:adapter"
+        module = "pkgmod.sub"
+        dist = None
+
+        def load(self):
+            return types.SimpleNamespace(read_img=lambda _path: "ok")
+
+    monkeypatch.setattr(img_libs_pkgs, "entry_points", lambda **kwargs: [FakeEntryPoint()])
+    monkeypatch.setattr(img_libs_pkgs, "find_spec", lambda _name: object())
+    def _missing(_pkg):
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(read_img, "pkg_version", _missing)
+    _clear_caches()
+
+    versions = read_img.get_read_img_version()
+    assert versions["no_dist_backend"] == "unknown"


### PR DESCRIPTION
Split builtin image backends into core and additional categories to ensure consistent ordering where core backends (PIL, accimage, jpeg4py, etc.) are listed before optional Rust-based backends (local_rs, imgread_rs).</think>docs: update plugin system documentation with usage examples